### PR TITLE
feat: update switch: Gateron Baby Kangaroo 2.0

### DIFF
--- a/src/switches/gateron/gateron/baby-kangaroo.ts
+++ b/src/switches/gateron/gateron/baby-kangaroo.ts
@@ -7,11 +7,11 @@ import {
 import { Color, Force, Tolerance, Travel } from '../../../types';
 
 export default {
-    model: 'Baby Kangaroo',
+    model: 'Baby Kangaroo 2.0',
     profile: 'regular',
     stem: StemMX.Regular(Material.POM(Color.Opaque('#97D5A9'))),
     type: 'tactile',
-    lifetime: 60,
+    lifetime: 80,
     mount: '5pin',
     lighting: 'smd',
     volume: 'medium',


### PR DESCRIPTION
In the 2.0 release, it looks like the operation life has increased from 60M to 80M cycles according to the information in the product page: https://www.gateron.co/products/gateron-baby-kangaroo-tactile-switch-set